### PR TITLE
Add prototype for ruby worker runtime

### DIFF
--- a/scans/worker.rb
+++ b/scans/worker.rb
@@ -1,0 +1,44 @@
+require 'aws-sdk-dynamodb'
+
+def worker(event:, context:)
+  event["Records"].each do | record |
+    if not record["eventName"] == "INSERT":
+      next
+    end
+
+    image = record["dynamodb"]["NewImage"]
+    scan_id = image["id"]["S"]
+    target = image["target"]["S"]
+    port = image["port"]["N"]).to_i
+
+    # TODO: Add real scan logic here to populate scan var, probably via a scan-engine
+    scan = {
+        'target': target,
+        'port': port,
+        'foo': 'bar'
+    }
+    sleep(5)
+
+    dynamodb = Aws::DynamoDB::Client.new(region: 'us-west-2')
+
+    dynamodb.update_item({
+      expression_attribute_names: {
+        "#st" => "status", 
+        "#sc" => "scan", 
+      }, 
+      expression_attribute_values: {
+        ":st" => {
+          s: "COMPLETED", 
+        }, 
+        ":sc" => scan, 
+      }, 
+      key: {
+        "id" => {
+          s: scan_id, 
+        }
+      }, 
+      table_name: ENV['DYNAMODB_TABLE'], 
+      update_expression: "SET #statusresult = :st, #scanresult = :sc", 
+    })
+  end
+end

--- a/serverless.yml
+++ b/serverless.yml
@@ -48,7 +48,21 @@ functions:
           method: get
           cors: true
 
+  # # Python Worker Skeleton
+  # worker:
+  #   handler: scans/worker.worker
+  #   events:
+  #     - stream:
+  #         type: dynamodb
+  #         arn:
+  #           Fn::GetAtt:
+  #             - ScansDynamoDbTable
+  #             - StreamArn
+  #         batchSize: 1
+
+  # Ruby Worker Skeleton
   worker:
+    runtime: ruby2.5
     handler: scans/worker.worker
     events:
       - stream:


### PR DESCRIPTION
This attempts to build out a facility where by we might be able to simple require in 'ssh_scan' and utilize the raw scan_engine class directly within a lambda handler short-cutting the need to rewrite the core engine in something like Python.